### PR TITLE
Move decks to GitHub repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,9 +15,10 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Imports: 
     cli,
+    gh,
     revealjs,
     rmarkdown
 Depends: 

--- a/R/flashcard.R
+++ b/R/flashcard.R
@@ -88,7 +88,7 @@ flashcard <- function(x,
 
   # Save HTML file when requested
   if (!is.null(file)) {
-    if (identical(tolower(xfun::file_ext(file)), "html")) {
+    if (identical(tolower(tools::file_ext(file)), "html")) {
       file.copy(from = htmlfile, to = file, overwrite = TRUE)
     } else {
       cli::cli_abort("Output files must be HTML or html.")
@@ -106,7 +106,7 @@ flashcard <- function(x,
 
 validate_deck <- function(x, package = package) {
   # Convert all deck objects to strings
-  valid_decks <- get_decks()
+  valid_decks <- list_decks(quiet = TRUE)
   if (is.character(x)) {
     input <- x
   } else {
@@ -115,7 +115,7 @@ validate_deck <- function(x, package = package) {
 
   # Validate input
   if (length(input) > 1) {
-    cli::cli_abort("Input is a vector rather than built-in deck or CSV file.")
+    cli::cli_abort("Input is a vector rather than available deck or CSV file.")
   }
 
   if (grepl(".csv", input)) { # if input is CSV file
@@ -133,14 +133,12 @@ validate_deck <- function(x, package = package) {
 
   } else if (input %in% valid_decks$decklabels) { # if input is found in valid decks
     # Get deck and deckname
-    deck <- eval(parse(text = input))
+    deck <- utils::read.csv(paste0("https://raw.githubusercontent.com/JeffreyRStevens/flashr_decks/main/decks/", input, ".csv"))
     deckname <- input
-
-    # Get title from data frame or use object name
-    title <- attr(deck, "title")
+    title <- deck$title[1]
 
   } else { # if input is not CSV or valid deck
-    cli::cli_abort("This deck is not recognized as a built-in deck or a valid CSV file.")
+    cli::cli_abort("This deck is not recognized as a available deck or a valid CSV file.")
   }
 
   # Check if package column is present if package = TRUE

--- a/R/list_decks.R
+++ b/R/list_decks.R
@@ -1,59 +1,120 @@
 
-#' List available built-in flashcard decks
+#' List available available flashcard decks
 #'
+#' @description This function searches for flashcard decks stored in GitHub
+#' repositories. By default, the function searches the
+#' [flashr_decks repo]("https://github.com/JeffreyRStevens/flashr_decks/"). But
+#' other GitHub repos can be used.
+#'
+#' To narrow the results, include text in the `pattern` argument (for example,
+#' `list_decks(pattern = "r4ds")`).
+#'
+#' @details You are welcome to fork the
+#' [flashr_decks repo]("https://github.com/JeffreyRStevens/flashr_decks/") and
+#' modify or add your own decks. Or you can create your own repo from scratch.
+#' Just make sure to place your decks in a directory called `decks/` in your
+#' root directory. Then set the `repo` argument to your username and repo (see
+#' Examples).
+#'
+#' @param pattern String pattern to search in list of decks.
+#' @param repo GitHub username and repo for deck repository in the format
+#' of "username/repository". Default value is "JeffreyRStevens/flashr_decks".
 #' @param quiet Logical to prevent list information from printing to console.
 #'
 #' @return
 #' Outputs a list of available built-in flashcard decks to the console.
 #' @export
 #'
+#' @family functions for finding decks
+#'
 #' @examples
+#' # View all available decks
 #' list_decks()
-list_decks <- function(quiet = FALSE) {
-  available_decks <- get_decks()
+#'
+#' # View decks with text matching pattern
+#' list_decks(pattern = "r4ds")
+#'
+#' # View decks from specific repository
+#' list_decks(repo = "JeffreyRStevens/flashr_decks")
+list_decks <- function(pattern = NULL,
+                       repo = "JeffreyRStevens/flashr_decks",
+                       quiet = FALSE) {
+  repo_text <- paste0("GET /repos/", repo, "/contents/decks")
+  deckfiles <- gh::gh(repo_text) |>
+    vapply("[[", "", "name")
+  deckpaths <- paste0("https://raw.githubusercontent.com/", repo, "/main/decks/", deckfiles)
+  decklabels <- gsub(".csv", "", deckfiles)
+  titles <- vapply(deckpaths, get_title, character(1))
+  decks <- paste0(titles, " (", decklabels, ")")
+  if (!is.null(pattern)) {
+    if (!is.character(pattern)) {
+      pattern <- deparse(substitute(pattern))
+    }
+    deck_nums <- grep(pattern, decks, ignore.case = TRUE)
+    decks <- decks[deck_nums]
+    decklabels <- decklabels[deck_nums]
+    titles <- titles[deck_nums]
+    if (length(decks) == 0) {
+      cli::cli_abort("No decks match the pattern entered. Try another pattern string.")
+    }
+  }
   if (!quiet) {
     cli::cli_text("Available flashcard decks")
-    cli::cli_ol(available_decks$decks)
+    cli::cli_ol(decks)
   }
+  invisible(list(decklabels = decklabels, decktitles = unname(titles), decks = decks))
 }
 
 #' Choose from available flashcard decks
 #'
-#' @param x Name of deck to directly generate flashcards (allows choose_deck()
-#' to act as wrapper for flashcard()).
+#' @description This function prints a list of flashcard decks to the console
+#' and let's the user choose one of the decks. By default, the function searches the
+#' [flashr_decks repo]("https://github.com/JeffreyRStevens/flashr_decks/"). But
+#' other GitHub repos can be used.
+#'
+#' To narrow the results, include text in the `pattern` argument (for example,
+#' `choose_deck(pattern = "r4ds")`).
+#'
+#' @param pattern String pattern to search in list of decks.
+#' @param repo GitHub username and repo for deck repository in the format
+#' of "username/repository". Default value is "JeffreyRStevens/flashr_decks".
 #'
 #' @return
 #' Outputs a list of available built-in flashcard decks to the console, where
-#' the user can choose of the decks to generate flashcards.
+#' the user can choose one of the decks to generate flashcards.
 #' @export
 #'
+#' @family functions for finding decks
+#'
 #' @examples
-choose_deck <- function(x = NULL) {
-  if (!is.null(x)) {
-    flashcard(x)
-  } else {
-    list_decks()
-    choice <- readline(prompt = "Please enter the number for a deck: ")
+#' \dontrun{
+#' # Choose from all available decks in default repository
+#' choose_deck()
+#'
+#' # Choose from decks including text matching pattern
+#' choose_deck(pattern = "r4ds")
+#'
+#' # Choose from decks from specific repository
+#' choose_deck(repo = "JeffreyRStevens/flashr_decks")
+#' }
+choose_deck <- function(pattern = NULL,
+                        repo = "JeffreyRStevens/flashr_decks") {
+    deck_list <- list_decks(pattern = pattern, repo = repo)
+    choice <- readline(prompt = "Please enter the number for a deck or 0 to exit: ")
     choice <- as.numeric(gsub("\\.", "", choice))
-    print(choice)
+    # print(choice)
+    decks <- deck_list$decks
+    decklabels <- deck_list$decklabels
+    titles <- deck_list$decktitles
     if (choice %in% 1:length(decks)) {
       cli::cli_text("Creating {.field ", {unname(titles[choice])}, "} deck.")
-      deck <- eval(parse(text = decklabels[choice]))
       flashcard(decklabels[choice])
-    } else {
+    } else if (identical(choice, 0)) {
+      invisible()
+    } else{
       cli::cli_abort("That response was not valid. Please rerun `choose_deck()` and enter a valid number for an available deck.")
     }
   }
-}
-
-get_decks <- function() {
-  deckfiles <- list.files(path = ("inst/extdata/"))
-  deckpaths <- paste0("inst/extdata/", deckfiles)
-  decklabels <- gsub(".csv", "", deckfiles)
-  titles <- vapply(deckpaths, get_title, character(1))
-  decks <- paste0(titles, " (", decklabels, ")")
-  invisible(list(decklabels = decklabels, decktitles = unname(titles), decks = decks))
-}
 
 get_title <- function(x) {
   data <- utils::read.csv(x)

--- a/man/choose_deck.Rd
+++ b/man/choose_deck.Rd
@@ -4,16 +4,41 @@
 \alias{choose_deck}
 \title{Choose from available flashcard decks}
 \usage{
-choose_deck(x = NULL)
+choose_deck(pattern = NULL, repo = "JeffreyRStevens/flashr_decks")
 }
 \arguments{
-\item{x}{Name of deck to directly generate flashcards (allows choose_deck()
-to act as wrapper for flashcard()).}
+\item{pattern}{String pattern to search in list of decks.}
+
+\item{repo}{GitHub username and repo for deck repository in the format
+of "username/repository". Default value is "JeffreyRStevens/flashr_decks".}
 }
 \value{
 Outputs a list of available built-in flashcard decks to the console, where
-the user can choose of the decks to generate flashcards.
+the user can choose one of the decks to generate flashcards.
 }
 \description{
-Choose from available flashcard decks
+This function prints a list of flashcard decks to the console
+and let's the user choose one of the decks. By default, the function searches the
+\href{"https://github.com/JeffreyRStevens/flashr_decks/"}{flashr_decks repo}. But
+other GitHub repos can be used.
+
+To narrow the results, include text in the \code{pattern} argument (for example,
+\code{choose_deck(pattern = "r4ds")}).
 }
+\examples{
+\dontrun{
+# Choose from all available decks in default repository
+choose_deck()
+
+# Choose from decks including text matching pattern
+choose_deck(pattern = "r4ds")
+
+# Choose from decks from specific repository
+choose_deck(repo = "JeffreyRStevens/flashr_decks")
+}
+}
+\seealso{
+Other functions for finding decks: 
+\code{\link{list_decks}()}
+}
+\concept{functions for finding decks}

--- a/man/flashcard.Rd
+++ b/man/flashcard.Rd
@@ -4,7 +4,7 @@
 \alias{flashcard}
 \title{Create flashcards}
 \usage{
-flashcard(x, termsfirst = TRUE, package = TRUE, theme = "moon")
+flashcard(x, termsfirst = TRUE, package = TRUE, theme = "moon", file = NULL)
 }
 \arguments{
 \item{x}{Name of pre-existing flashcard deck or path and name of CSV file
@@ -16,6 +16,9 @@ descriptions first (FALSE)}
 \item{package}{Logical indicating whether to include package name in term}
 
 \item{theme}{Name of reveal.js theme to use for flashcards}
+
+\item{file}{Path and file name used to save flashcard deck locally (must
+save as HTML)}
 }
 \value{
 An HTML file of terms and descriptions rendered in the RStudio viewer or

--- a/man/list_decks.Rd
+++ b/man/list_decks.Rd
@@ -2,19 +2,54 @@
 % Please edit documentation in R/list_decks.R
 \name{list_decks}
 \alias{list_decks}
-\title{List available built-in flashcard decks}
+\title{List available available flashcard decks}
 \usage{
-list_decks(quiet = FALSE)
+list_decks(
+  pattern = NULL,
+  repo = "JeffreyRStevens/flashr_decks",
+  quiet = FALSE
+)
 }
 \arguments{
+\item{pattern}{String pattern to search in list of decks.}
+
+\item{repo}{GitHub username and repo for deck repository in the format
+of "username/repository". Default value is "JeffreyRStevens/flashr_decks".}
+
 \item{quiet}{Logical to prevent list information from printing to console.}
 }
 \value{
 Outputs a list of available built-in flashcard decks to the console.
 }
 \description{
-List available built-in flashcard decks
+This function searches for flashcard decks stored in GitHub
+repositories. By default, the function searches the
+\href{"https://github.com/JeffreyRStevens/flashr_decks/"}{flashr_decks repo}. But
+other GitHub repos can be used.
+
+To narrow the results, include text in the \code{pattern} argument (for example,
+\code{list_decks(pattern = "r4ds")}).
+}
+\details{
+You are welcome to fork the
+\href{"https://github.com/JeffreyRStevens/flashr_decks/"}{flashr_decks repo} and
+modify or add your own decks. Or you can create your own repo from scratch.
+Just make sure to place your decks in a directory called \verb{decks/} in your
+root directory. Then set the \code{repo} argument to your username and repo (see
+Examples).
 }
 \examples{
+# View all available decks
 list_decks()
+
+# View decks with text matching pattern
+list_decks(pattern = "r4ds")
+
+# View decks from specific repository
+list_decks(repo = "JeffreyRStevens/flashr_decks")
 }
+\seealso{
+Other functions for finding decks: 
+\code{\link{choose_deck}()}
+}
+\concept{functions for finding decks}

--- a/tests/testthat/test-list_decks.R
+++ b/tests/testthat/test-list_decks.R
@@ -6,16 +6,16 @@ test_that("list_decks works", {
 })
 
 test_that("choose_decks works", {
-  expect_error(choose_deck(letters))
+  # expect_error(choose_deck(letters))
   # suppressMessages(expect_message(choose_deck(), "Available flashcard decks"))
 })
 
 test_that("get_decks works", {
-  test_decks <- get_decks()
+  test_decks <- list_decks(quiet = TRUE)
   expect_equal(test_decks$decklabels[1], "data_types")
   expect_equal(test_decks$decktitles[1], "Data types")
   expect_equal(test_decks$decks[1], "Data types (data_types)")
-  expect_invisible(get_decks())
+  expect_invisible(list_decks(quiet = TRUE))
 })
 
 test_that("get_title works", {


### PR DESCRIPTION
This moves the decks to https://github.com/JeffreyRStevens/flashr_decks repo.
* The `get_decks()` function has been move to inside `list_decks()`
* Decks are accessed via the `{gh}` package function `gh()`
* Other repositories can be accessed with the `repo` argument for the `list_decks()` and `choose_deck()` functions
* Listing decks uses pattern matching
* Added documentation for `list_decks()` and `choose_deck()` functions