### PR TITLE
Remove backticks when LaTeX code is present in term (#27)

### DIFF
--- a/R/flashcard.R
+++ b/R/flashcard.R
@@ -368,7 +368,11 @@ build_deck <- function(deck,
   # Create slides for each item
   for (i in seq_len(nrow(items))) {
     # Create slide components
-    term <- paste0("`", items$term[i], "`")
+    if (grepl("\\$(.*?)\\$", items$term[i])) {
+      term <- items$term[i]
+    } else {
+      term <- paste0("`", items$term[i], "`")
+    }
     # Add URL if included in deck
     if ("url" %in% names(deck)) {
       if (!is.na(items$url[i])) {


### PR DESCRIPTION
LaTeX syntax was not rendering in terms because they are surrounded in backticks to format code style. This fix detects the presence of text surrounded by `$` and does not use backticks for those terms. 
An internet connection is required to render the LaTeX syntax.